### PR TITLE
Include raw content via archive downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/*
 
 tmp/*
 scratch.*
+.vscode

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -81,10 +81,6 @@ if (args['--after']) {
   }
 }
 
-function outputFileName (version, tag = 'content', extension = 'html') {
-  return `${version.siteId}-${version.pageId}-${version.versionId}-${tag}.${extension}`;
-}
-
 // FIXME: this should be encapsulated in a function
 let baseDirectory = process.cwd();
 if (args['--output']) {
@@ -110,7 +106,10 @@ function writeFile (name, content, encoding = 'utf8') {
 }
 
 let errorStream;
-function writeError (error) {
+let errorCount = 0;
+function logError (error) {
+  errorCount++;
+
   if (!errorStream) {
     if (args['--errors']) {
       errorStream = fs.createWriteStream(args['--errors']);
@@ -120,7 +119,7 @@ function writeError (error) {
     }
   }
 
-  errorStream.write(error);
+  errorStream.write(error.stack || error.message || error.toString());
   errorStream.write('\n');
 }
 
@@ -172,101 +171,6 @@ const isInRequestedDateRange = (testDate) => {
 const formatter = formatters[args['--format']] || formatters.json;
 const startTime = Date.now();
 
-
-// const versionStream = new stream.PassThrough({objectMode: true});
-// scraper.streamSites().on('data', site => {
-//   scraper.streamPages(site).on('data', page => {
-//     scraper.streamVersions(page).on('data', version => {
-//       versionStream.write(version);
-//     });
-//   });
-// });
-
-// const through2Stream = (concurrency, transformer) => {
-//   return through2Concurrent({maxConcurrency}, function (item, enc, callback) {
-//     transformer(item)
-//       .on('data', this.push.bind(this))
-//       .on('error', callback)
-//       .on('end', () => callback());
-//   });
-// }
-
-// const streamFilter = (filterFunction) => through2((data, enc, callback) =>  {
-//   try {
-//     callback(null, filterFunction(data) ? data : null);
-//   }
-//   catch (error) {
-//     callback(error);
-//   }
-// });
-
-// const versionStream = scraper.streamSites()
-//   .pipe(streamFilter(isInRequestedDateRange))
-//   .pipe(through2Stream(6, site => scraper.streamPages(site)))
-//   .pipe(streamFilter(isInRequestedDateRange))
-//   .pipe(through2Stream(6, page => scraper.streamVersions(page)))
-//   .pipe(streamFilter(isInRequestedDateRange))
-//   // .pipe(through2Stream(6, version => ))
-//   // .pipe(through2Stream(6, site => scraper.streamPages(site)))
-
-
-// const versionStream = scraper.streamSites()
-//   .pipe(streamFilter(isInRequestedDateRange))
-//   .pipe(parallel(6, (site, callback) => {
-//     scraper.streamPages(site)
-//       .on('data', this.push.bind(this))
-//       .on('error', callback)
-//       .on('end', () => callback());
-//   }))
-//   .pipe(streamFilter(isInRequestedDateRange))
-//   .pipe(parallel(6, (page, callback) => {
-//     scraper.streamVersions(page)
-//       .on('data', this.push.bind(this))
-//       .on('error', callback)
-//       .on('end', () => callback());
-//   }))
-//   .pipe(streamFilter(isInRequestedDateRange))
-//   .pipe(parallel(6, (version, callback) => {
-//     const diffStream = scraper.streamVersionDiff(version.diffWithPreviousUrl)
-//       .on('metadata', metadata => {
-//         version.diff = version.diff || {};
-//         Object.assign(version.diff, metadata);
-//         callback(null, version);
-//       })
-//       .on('error', error => {
-//         if (error.code !== 'VERSIONISTA:INVALID_URL') {
-//           encounteredErrors++;
-//           writeError(error.message);
-//         }
-//         callback(null, version);
-//       });
-
-//     if (args['--save-diffs']) {
-//       const diffPath = path.join(pagePath, `diff-${version.versionId}.html`);
-//       version.diff = {path: diffPath};
-//       diffStream.pause();
-//       mkdirp(pagePath, error => {
-//         if (error) {
-//           diffStream.emit('error', error);
-//         }
-//         else {
-//           diffStream.pipe(fs.createWriteStream(diffPath));
-//         }
-//         diffStream.resume();
-//       });
-//     }
-//   }));
-
-// if (args['--save-content']) {
-//   pageStream
-//     .pipe(parallel(6, function (page, callback) {
-
-//     }))
-//     .on('end', )
-// }
-
-let encounteredErrors = 0;
-
 function archiveVersionDiff (version) {
   if (!version.diffWithPreviousUrl) {
     return;
@@ -301,8 +205,7 @@ function archiveVersionDiff (version) {
       // ask for the diff, so this is "ok"
       // otherwise, log error but continue working
       if (error.code !== 'VERSIONISTA:INVALID_URL') {
-        encounteredErrors++;
-        writeError(error.message);
+        logError(error);
       }
     })
     .then(() => version);
@@ -370,8 +273,7 @@ function archivePageVersions (page, versions) {
     }))
     .catch(error => {
       // emit messages here and allow the process to continue
-      encounteredErrors++;
-      writeError(error.message);
+      logError(error);
     });
 }
 
@@ -432,8 +334,7 @@ versions
   .then(data => formatter(data, {
     email: args['--email'],
     includeDiffs: args['--save-diffs'],
-    includeContent: args['--save-content'],
-    outputFileName: outputFileName
+    includeContent: args['--save-content']
   }))
   .then(formatted => {
     if (args['--output']) {
@@ -444,15 +345,14 @@ versions
     }
   })
   .catch(error => {
-    console.error(error.stack);
-    encounteredErrors++;
+    logError(error);
   })
   .then(() => {
     const seconds = Math.round((Date.now() - startTime) / 1000);
     console.error(`Completed in ${seconds} seconds`);
-    if (encounteredErrors) {
-      console.error(`  with ${encounteredErrors} errors`);
+    if (errorCount) {
+      console.error(`  with ${errorCount} errors`);
     }
     flushErrors();
-    process.exit(encounteredErrors ? 1 : 0);
+    process.exit(errorCount ? 1 : 0);
   });

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -190,10 +190,12 @@ let basicMetadata = scraper.logIn()
                       // it’s possible for Versionista to consign a version to
                       // the ether between the time we detect the version and
                       // ask for the diff, so this is "ok"
-                      if (error.code === 'VERSIONISTA:INVALID_URL') {
-                        return version;
+                      // otherwise, log error but continue working
+                      if (error.code !== 'VERSIONISTA:INVALID_URL') {
+                        encounteredErrors++;
+                        writeError(error.message);
                       }
-                      return Promise.reject(error);
+                      return version;
                     });
                 }))
                   // attach versions to pages

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -376,8 +376,7 @@ function archivePageVersions (page, versions) {
 }
 
 
-let sites = scraper.logIn()
-  .then(() => scraper.getSites())
+let sites = scraper.getSites()
   .then(sites => sites.filter(isInRequestedDateRange))
   .then(sites => {
     console.error(`Found ${sites.length} sites with potential updates`);

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -6,8 +6,8 @@ const stream = require('stream');
 const fs = require('fs-promise');
 const mkdirp = require('mkdirp');
 const neodoc = require('neodoc');
-const unzip = require('unzip-stream');
 const Versionista = require('..');
+const flatten = require('../lib/flatten');
 require('../lib/polyfill');
 
 const formatters = {
@@ -85,19 +85,20 @@ function outputFileName (version, tag = 'content', extension = 'html') {
   return `${version.siteId}-${version.pageId}-${version.versionId}-${tag}.${extension}`;
 }
 
+// FIXME: this should be encapsulated in a function
+let baseDirectory = process.cwd();
+if (args['--output']) {
+  baseDirectory = path.dirname(args['--output']);
+}
+
 let directoryIsReady = false;
 function writeFile (name, content, encoding = 'utf8') {
-  let directory = process.cwd();
-  if (args['--output']) {
-    directory = path.dirname(args['--output']);
-  }
-
-  const filePath = path.join(directory, name);
+  const filePath = path.join(baseDirectory, name);
   const writeIt = () => fs.writeFile(filePath, content, encoding);
 
   if (!directoryIsReady) {
     return new Promise((resolve, reject) => {
-      mkdirp(directory, (error, created) => {
+      mkdirp(baseDirectory, (error, created) => {
         if (error) return reject(error);
         directoryIsReady = true;
         resolve(created);
@@ -129,10 +130,6 @@ function flushErrors () {
   }
 }
 
-function pageHasDownloadableVersions (page) {
-  return page.versions.some(version => version.hasContent);
-}
-
 function minimum (items, getValue = Number) {
   let smallestValue = Infinity;
   let smallestItem = null;
@@ -155,220 +152,294 @@ const isAfterMinimumDate = (testDate) => {
   return !args['--after'] || args['--after'] <= testDate;
 };
 
+const isBeforeMaximumDate = (testDate) => {
+  return !args['--before'] || args['--before'] >= testDate;
+};
+
 const isInRequestedDateRange = (testDate) => {
-  return isAfterMinimumDate(testDate) &&
-    (!args['--before'] || args['--before'] >= testDate);
+  if (testDate instanceof Date) {
+    return isAfterMinimumDate(testDate) && isBeforeMaximumDate(testDate);
+  }
+  else if (testDate.date) {
+    return isInRequestedDateRange(testDate.date);
+  }
+  else if (testDate.lastChange) {
+    return isAfterMinimumDate(testDate.lastChange);
+  }
+  throw new Error(`Cannot apply date filter to: ${JSON.stringify(testDate)}`);
 }
 
 const formatter = formatters[args['--format']] || formatters.json;
 const startTime = Date.now();
 
+
+// const versionStream = new stream.PassThrough({objectMode: true});
+// scraper.streamSites().on('data', site => {
+//   scraper.streamPages(site).on('data', page => {
+//     scraper.streamVersions(page).on('data', version => {
+//       versionStream.write(version);
+//     });
+//   });
+// });
+
+// const through2Stream = (concurrency, transformer) => {
+//   return through2Concurrent({maxConcurrency}, function (item, enc, callback) {
+//     transformer(item)
+//       .on('data', this.push.bind(this))
+//       .on('error', callback)
+//       .on('end', () => callback());
+//   });
+// }
+
+// const streamFilter = (filterFunction) => through2((data, enc, callback) =>  {
+//   try {
+//     callback(null, filterFunction(data) ? data : null);
+//   }
+//   catch (error) {
+//     callback(error);
+//   }
+// });
+
+// const versionStream = scraper.streamSites()
+//   .pipe(streamFilter(isInRequestedDateRange))
+//   .pipe(through2Stream(6, site => scraper.streamPages(site)))
+//   .pipe(streamFilter(isInRequestedDateRange))
+//   .pipe(through2Stream(6, page => scraper.streamVersions(page)))
+//   .pipe(streamFilter(isInRequestedDateRange))
+//   // .pipe(through2Stream(6, version => ))
+//   // .pipe(through2Stream(6, site => scraper.streamPages(site)))
+
+
+// const versionStream = scraper.streamSites()
+//   .pipe(streamFilter(isInRequestedDateRange))
+//   .pipe(parallel(6, (site, callback) => {
+//     scraper.streamPages(site)
+//       .on('data', this.push.bind(this))
+//       .on('error', callback)
+//       .on('end', () => callback());
+//   }))
+//   .pipe(streamFilter(isInRequestedDateRange))
+//   .pipe(parallel(6, (page, callback) => {
+//     scraper.streamVersions(page)
+//       .on('data', this.push.bind(this))
+//       .on('error', callback)
+//       .on('end', () => callback());
+//   }))
+//   .pipe(streamFilter(isInRequestedDateRange))
+//   .pipe(parallel(6, (version, callback) => {
+//     const diffStream = scraper.streamVersionDiff(version.diffWithPreviousUrl)
+//       .on('metadata', metadata => {
+//         version.diff = version.diff || {};
+//         Object.assign(version.diff, metadata);
+//         callback(null, version);
+//       })
+//       .on('error', error => {
+//         if (error.code !== 'VERSIONISTA:INVALID_URL') {
+//           encounteredErrors++;
+//           writeError(error.message);
+//         }
+//         callback(null, version);
+//       });
+
+//     if (args['--save-diffs']) {
+//       const diffPath = path.join(pagePath, `diff-${version.versionId}.html`);
+//       version.diff = {path: diffPath};
+//       diffStream.pause();
+//       mkdirp(pagePath, error => {
+//         if (error) {
+//           diffStream.emit('error', error);
+//         }
+//         else {
+//           diffStream.pipe(fs.createWriteStream(diffPath));
+//         }
+//         diffStream.resume();
+//       });
+//     }
+//   }));
+
+// if (args['--save-content']) {
+//   pageStream
+//     .pipe(parallel(6, function (page, callback) {
+
+//     }))
+//     .on('end', )
+// }
+
 let encounteredErrors = 0;
-let basicMetadata = scraper.logIn()
-  .then(() => scraper.getSites())
-  // TODO: rewrite this as a series or more readable sequential transforms
-  // instead of nested ones.
-  .then(siteData => {
-    const updatedSites = siteData.filter(site => isAfterMinimumDate(site.lastChange));
-    let totalSites = updatedSites.length;
-    let completedSites = 0;
-    console.error(`Found ${totalSites} (of ${siteData.length}) sites with updates.`);
 
-    return Promise.all(updatedSites.map(site => {
-      return scraper.getPages(site.url)
-        .then(pages => {
-          completedSites++;
-          const updatedPages = pages.filter(page => isAfterMinimumDate(page.lastChange));
-          console.error(`Found ${pages.length} pages (${updatedPages.length} w/ updates) for ${site.name} (${completedSites}/${totalSites} sites checked)`);
+function archiveVersionDiff (version) {
+  if (!version.diffWithPreviousUrl) {
+    return;
+  }
 
-          return Promise.all(updatedPages.map(page => {
-            return scraper.getVersions(page.versionistaUrl)
-              .then(versions => {
-                const newVersions = versions.filter(version => isInRequestedDateRange(version.date));
-                console.error(`In ${page.url}:\n  ${versions.length} versions\n  ${newVersions.length} new versions`);
+  const pageDirectory = `${version.siteId}-${version.pageId}`;
+  const pagePath = path.join(baseDirectory, pageDirectory);
 
-                // FIXME: this is duplicated in the content-saving logic below
-                let baseDirectory = process.cwd();
-                if (args['--output']) {
-                  baseDirectory = path.dirname(args['--output']);
-                }
-                const pageDirectory = `${site.id}-${page.id}`;
-                const pagePath = path.join(baseDirectory, pageDirectory);
+  return scraper.getVersionDiff(version.diffWithPreviousUrl)
+    .then(diff => {
+      if (diff) {
+        version.diff = {
+          hash: diff.hash,
+          length: diff.length
+        };
 
-                return Promise.all(newVersions.map(version => {
-                  if (!version.diffWithPreviousUrl) return version;
-                  return scraper.getVersionDiff(version.diffWithPreviousUrl)
-                    .then(diff => {
-                      if (diff) {
-                        version.diff = {
-                          hash: diff.hash,
-                          length: diff.length
-                        };
-
-                        if (args['--save-diffs']) {
-                          const diffPath = path.join(
-                            pagePath,
-                            `diff-${version.versionId}.html`
-                          );
-                          version.diff.path = diffPath;
-                          return fs.ensureDir(pagePath)
-                            .then(() => fs.writeFile(diffPath, diff.content))
-                            .then(() => version);
-                        }
-                      }
-
-                      return version;
-                    })
-                    .catch(error => {
-                      // it’s possible for Versionista to consign a version to
-                      // the ether between the time we detect the version and
-                      // ask for the diff, so this is "ok"
-                      // otherwise, log error but continue working
-                      if (error.code !== 'VERSIONISTA:INVALID_URL') {
-                        encounteredErrors++;
-                        writeError(error.message);
-                      }
-                      return version;
-                    });
-                }))
-                  // attach versions to pages
-                  .then(versions => Object.assign({versions}, page));
-              });
-          }))
-            // attach pages to site
-            .then(pages => Object.assign({pages}, site));
-        });
-    }));
-  });
-
-function saveMetadata (sites) {
-  return Promise.resolve(sites)
-    .then(data => formatter(data, {
-      email: args['--email'],
-      includeDiffs: args['--save-diffs'],
-      includeContent: args['--save-content'],
-      outputFileName: outputFileName
-    }))
-    .then(formatted => {
-      if (args['--output']) {
-        return writeFile(path.basename(args['--output']), formatted);
-      }
-      else {
-        process.stdout.write(formatted);
-      }
-    });
-}
-
-// save the metadata as-is before doing more work
-saveMetadata(basicMetadata);
-
-if (args['--save-content']) {
-  const unmatchedVersions = new Set();
-  basicMetadata = basicMetadata.then(sites => {
-    const workTasks = [];
-    sites.forEach(site => {
-      site.pages
-        .filter(pageHasDownloadableVersions)
-        .forEach(page => {
-          // track list of versions that we *should* see in archives
-          page.versions
-            .filter(version => version.hasContent)
-            .forEach(version => {
-              unmatchedVersions.add(version.versionId);
-            });
-
-          let baseDirectory = process.cwd();
-          if (args['--output']) {
-            baseDirectory = path.dirname(args['--output']);
-          }
-          const pageDirectory = `${site.id}-${page.id}`;
-          const pagePath = path.join(baseDirectory, pageDirectory);
-          const task = fs.ensureDir(pagePath)
-            .then(() => scraper.getVersionArchive(page.versionistaUrl))
-            .then(content => {
-              return new Promise((resolve, reject) => {
-                let writing = 1;
-                let errors = [];
-                const complete = (error) => {
-                  error && errors.push(error);
-                  writing = Math.max(0, writing - 1);
-                  if (writing === 0) {
-                    if (errors.length) {
-                      reject(errors.map(error => error.message).join('\n'));
-                    }
-                    else {
-                      resolve();
-                    }
-                  }
-                };
-                const contentStream = new stream.PassThrough();
-                contentStream.end(content);
-                contentStream.pipe(unzip.Parse())
-                  .on('entry', entry => {
-                    if (entry.type === 'File') {
-                      const [_, year, month, day, hour, minute, second, extension = ''] =
-                        entry.path.match(/^(\d{4})(\d\d)(\d\d)(\d\d)(\d\d)(\d\d)[^\.]*(\..*)?$/);
-                      const isoDate = `${year}-${month}-${day}T${hour}:${minute}:${second}Z`;
-                      const fileDate = new Date(isoDate);
-
-                      // Frustratingly, the timestamps on the files do not
-                      // match the timestamps on the version records. So...
-                      // find the closest matching timestamp, but also require
-                      // it to be within a narrow threshold.
-                      const allowableTimeframe = 30 * 60 * 1000;
-                      const fileVersion = minimum(page.versions, version => {
-                        const value = Math.abs(version.date - fileDate);
-                        return (value < allowableTimeframe) ? value : null;
-                      });
-
-                      let outputName = entry.path;
-                      if (fileVersion) {
-                        outputName = `version-${fileVersion.versionId}${extension}`;
-                        unmatchedVersions.delete(fileVersion.versionId);
-                        fileVersion.filePath = path.join(pagePath, outputName);
-                      }
-                      else if (args['--save-content'] !== 'all') {
-                        resolve();
-                        entry.autodrain();
-                        return;
-                      }
-
-                      const versionFile = path.join(pagePath, outputName);
-                      entry
-                        .pipe(fs.createWriteStream(versionFile))
-                        .on('error', complete)
-                        .on('close', () => complete());
-
-                      writing++;
-                    }
-                    else {
-                      entry.autodrain();
-                    }
-                  })
-                  .on('end', () => complete());
-              });
-            })
-            .catch(error => {
-              // emit messages here and allow the process to continue
-              encounteredErrors++;
-              writeError(error.message);
-            });
-          workTasks.push(task);
-        });
-    });
-    return Promise.all(workTasks)
-      .then(tasks => {
-        if (unmatchedVersions.size > 0) {
-          encounteredErrors++;
-          writeError(`${unmatchedVersions.size} versions not found in downloaded archives: ${Array.from(unmatchedVersions)}`);
+        if (args['--save-diffs']) {
+          version.diff.path = path.join(
+            baseDirectory,
+            `${version.siteId}-${version.pageId}`,
+            `diff-${version.versionId}.html`
+          );
+          return fs.ensureDir(pagePath)
+            .then(() => fs.writeFile(version.diff.path, diff.content))
+            .then(() => version);
         }
-      })
-      .then(() => sites);
-  });
+      }
+    })
+    .catch(error => {
+      // it’s possible for Versionista to consign a version to
+      // the ether between the time we detect the version and
+      // ask for the diff, so this is "ok"
+      // otherwise, log error but continue working
+      if (error.code !== 'VERSIONISTA:INVALID_URL') {
+        encounteredErrors++;
+        writeError(error.message);
+      }
+    })
+    .then(() => version);
 }
 
-// save again to get any updates from downloading raw versions
-saveMetadata(basicMetadata)
+function archivePageVersions (page, versions) {
+  const downloadableVersions = versions.filter(version => version.hasContent);
+
+  if (!downloadableVersions.length || !args['--save-content']) {
+    return Promise.resolve(page);
+  }
+
+  const siteId = versions[0].siteId;
+  const unmatchedVersions = new Set(
+    downloadableVersions.map(version => version.versionId)
+  );
+
+  const pageDirectory = `${siteId}-${page.id}`;
+  const pagePath = path.join(baseDirectory, pageDirectory);
+
+  return fs.ensureDir(pagePath)
+    .then(() => new Promise((resolve, reject) => {
+      scraper.getVersionArchiveEntries(page.versionistaUrl)
+        .pipe(stream.Transform({
+          objectMode: true,
+          transform: function (entry, encoding, callback) {
+            entry.resume();
+            // Frustratingly, the timestamps on the files do not
+            // match the timestamps on the version records. So...
+            // find the closest matching timestamp, but also require
+            // it to be within a narrow threshold.
+            const allowableTimeframe = 30 * 60 * 1000;
+            const fileVersion = minimum(versions, version => {
+              const timeApart = Math.abs(version.date - entry.date);
+              return (timeApart < allowableTimeframe) ? timeApart : null;
+            });
+
+            let outputName = entry.path;
+            if (fileVersion) {
+              outputName = `version-${fileVersion.versionId}${entry.extension}`;
+              unmatchedVersions.delete(fileVersion.versionId);
+              fileVersion.filePath = path.join(pagePath, outputName);
+              entry.on('hash', hash => fileVersion.hash = hash.toString('hex'));
+            }
+            else if (args['--save-content'] !== 'all') {
+              entry.autodrain();
+              return callback();
+            }
+
+            const versionFile = path.join(pagePath, outputName);
+            entry
+              .pipe(fs.createWriteStream(versionFile))
+              .on('error', callback)
+              .on('finish', callback);
+          }
+        }))
+        .resume()
+        // .on('data', () => null)
+        .on('error', reject)
+        .on('end', resolve);
+    }))
+    .catch(error => {
+      // emit messages here and allow the process to continue
+      encounteredErrors++;
+      writeError(error.message);
+    });
+}
+
+
+let sites = scraper.logIn()
+  .then(() => scraper.getSites())
+  .then(sites => sites.filter(isInRequestedDateRange))
+  .then(sites => {
+    console.error(`Found ${sites.length} sites with potential updates`);
+    return sites;
+  });
+
+let pages = sites
+  .then(sites => {
+    // TODO: remove need to create references between pages and sites
+    // return Promise.all(sites.map(site => scraper.getPages(site.url)));
+    const pagesForSites = sites.map(site => {
+      return scraper.getPages(site.url)
+        .then(pages => pages.filter(isInRequestedDateRange))
+        .then(pages => {
+          site.pages = pages;
+          return pages;
+        });
+    });
+    return Promise.all(pagesForSites).then(flatten);
+  })
+  .then(pages => {
+    console.error(`Found ${pages.length} pages with potential updates`);
+    return pages;
+  });
+
+let versions = pages
+  .then(pages => {
+    const versionsForPages = pages.map(page => {
+      const versions = scraper.getVersions(page.versionistaUrl);
+      const relevantVersions = versions
+        .then(versions => versions.filter(isInRequestedDateRange))
+        .then(versions => {
+          page.versions = versions;
+          return versions;
+        });
+
+      const archived = relevantVersions
+        .then(archivePageVersions.bind(null, page));
+      const diffed = relevantVersions
+        .then(versions => Promise.all(versions.map(archiveVersionDiff)))
+
+      return Promise.all([diffed, archived]).then(() => relevantVersions);
+    });
+    return Promise.all(versionsForPages).then(flatten);
+  })
+  .then(versions => {
+    console.error(`Found ${versions.length} versions with updates`);
+    return versions;
+  });
+
+versions
+  .then(() => sites)
+  .then(data => formatter(data, {
+    email: args['--email'],
+    includeDiffs: args['--save-diffs'],
+    includeContent: args['--save-content'],
+    outputFileName: outputFileName
+  }))
+  .then(formatted => {
+    if (args['--output']) {
+      return writeFile(path.basename(args['--output']), formatted);
+    }
+    else {
+      process.stdout.write(formatted);
+    }
+  })
   .catch(error => {
     console.error(error.stack);
     encounteredErrors++;

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -186,28 +186,48 @@ scraper.logIn()
     const workTasks = [];
     sites.forEach(site => {
       site.pages.forEach(page => {
-        page.versions.forEach(version => {
-          if (version.hasContent && args['--save-content']) {
-            const savedFile = scraper
-              .getVersionRawContent(version.url)
-              .then(html => writeFile(outputFileName(version), html))
-              .catch(error => {
-                encounteredErrors = true;
+        const savedArchive = scraper
+          .getVersionArchive(page.versionistaUrl)
+          .then(content => {
+            const fileName = outputFileName(
+              {
+                siteId: site.id,
+                pageId: page.id,
+                versionId: 'all'
+              },
+              'archive',
+              'zip');
+            return writeFile(fileName, content, null);
+          })
+          .catch(error => {
+            // emit messages here and allow the process to continue
+            encounteredErrors = true;
+            console.error(error.message);
+          });
+        workTasks.push(savedArchive);
 
-                // Do some nice logging for a failure to get content. Also
-                // don't stop the works for this particular error.
-                if (error.code === 'VERSIONISTA:NO_VERSION_CONTENT') {
-                  console.error(error.message);
-                  console.error('  Requested urls:', error.urls);
-                  console.error(`  Raw response: "${error.formattedContent}"`);
-                }
-                else {
-                  throw error;
-                }
-              });
-            workTasks.push(savedFile);
-          }
-        });
+        // page.versions.forEach(version => {
+        //   if (version.hasContent && args['--save-content']) {
+        //     const savedFile = scraper
+        //       .getVersionRawContent(version.url)
+        //       .then(html => writeFile(outputFileName(version), html))
+        //       .catch(error => {
+        //         encounteredErrors = true;
+
+        //         // Do some nice logging for a failure to get content. Also
+        //         // don't stop the works for this particular error.
+        //         if (error.code === 'VERSIONISTA:NO_VERSION_CONTENT') {
+        //           console.error(error.message);
+        //           console.error('  Requested urls:', error.urls);
+        //           console.error(`  Raw response: "${error.formattedContent}"`);
+        //         }
+        //         else {
+        //           throw error;
+        //         }
+        //       });
+        //     workTasks.push(savedFile);
+        //   }
+        // });
       });
     });
     return Promise.all(workTasks).then(() => sites);

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -206,12 +206,13 @@ let basicMetadata = scraper.logIn()
                         };
 
                         if (args['--save-diffs']) {
-                          const fileName = `diff-${version.versionId}.html`;
+                          const diffPath = path.join(
+                            pagePath,
+                            `diff-${version.versionId}.html`
+                          );
+                          version.diff.path = diffPath;
                           return fs.ensureDir(pagePath)
-                            .then(() => fs.writeFile(
-                              path.join(pagePath, fileName),
-                              diff.content
-                            ))
+                            .then(() => fs.writeFile(diffPath, diff.content))
                             .then(() => version);
                         }
                       }
@@ -240,22 +241,26 @@ let basicMetadata = scraper.logIn()
     }));
   });
 
+function saveMetadata (sites) {
+  return Promise.resolve(sites)
+    .then(data => formatter(data, {
+      email: args['--email'],
+      includeDiffs: args['--save-diffs'],
+      includeContent: args['--save-content'],
+      outputFileName: outputFileName
+    }))
+    .then(formatted => {
+      if (args['--output']) {
+        return writeFile(path.basename(args['--output']), formatted);
+      }
+      else {
+        process.stdout.write(formatted);
+      }
+    });
+}
+
 // save the metadata as-is before doing more work
-basicMetadata
-  .then(data => formatter(data, {
-    email: args['--email'],
-    includeDiffs: args['--save-diffs'],
-    includeContent: args['--save-content'],
-    outputFileName: outputFileName
-  }))
-  .then(formatted => {
-    if (args['--output']) {
-      return writeFile(path.basename(args['--output']), formatted);
-    }
-    else {
-      process.stdout.write(formatted);
-    }
-  });
+saveMetadata(basicMetadata);
 
 if (args['--save-content']) {
   const unmatchedVersions = new Set();
@@ -317,6 +322,7 @@ if (args['--save-content']) {
                       if (fileVersion) {
                         outputName = `version-${fileVersion.versionId}${extension}`;
                         unmatchedVersions.delete(fileVersion.versionId);
+                        fileVersion.filePath = path.join(pagePath, outputName);
                       }
                       else if (args['--save-content'] !== 'all') {
                         resolve();
@@ -358,7 +364,8 @@ if (args['--save-content']) {
   });
 }
 
-basicMetadata
+// save again to get any updates from downloading raw versions
+saveMetadata(basicMetadata)
   .catch(error => {
     console.error(error.stack);
     encounteredErrors++;

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -30,6 +30,7 @@ Options:
                        Or a number, representing hours before the current time
   --format FORMAT      Output format (csv|json|json-stream) [default: json]
   --output PATH        Write output to this file instead of STDOUT.
+  --errors PATH        Write error summary to this file instead of STDERR.
   --save-content       Save raw HTML of each version. Files are written to the
                        working directory or, if --output is specified, the same
                        directory as the output file.
@@ -98,6 +99,31 @@ function writeFile (name, content, encoding = 'utf8') {
   return writeIt();
 }
 
+let errorStream;
+function writeError (error) {
+  if (!errorStream) {
+    if (args['--errors']) {
+      errorStream = fs.createWriteStream(args['--errors']);
+    }
+    else {
+      errorStream = process.stderr;
+    }
+  }
+
+  errorStream.write(error);
+  errorStream.write('\n');
+}
+
+function flushErrors () {
+  if (errorStream && errorStream !== process.stderr) {
+    errorStream.end();
+  }
+}
+
+function pageHasDownloadableVersions (page) {
+  return page.versions.some(version => version.hasContent);
+}
+
 const scraper = new Versionista({
   email: args['--email'],
   password: args['--password']
@@ -115,8 +141,8 @@ const isInRequestedDateRange = (testDate) => {
 const formatter = formatters[args['--format']] || formatters.json;
 const startTime = Date.now();
 
-let encounteredErrors = false;
-scraper.logIn()
+let encounteredErrors = 0;
+let basicMetadata = scraper.logIn()
   .then(() => scraper.getSites())
   // TODO: rewrite this as a series or more readable sequential transforms
   // instead of nested ones.
@@ -178,61 +204,10 @@ scraper.logIn()
             .then(pages => Object.assign({pages}, site));
         });
     }));
-  })
-  // save versions
-  .then(sites => {
-    if (!args['--save-content']) return sites;
+  });
 
-    const workTasks = [];
-    sites.forEach(site => {
-      site.pages.forEach(page => {
-        const savedArchive = scraper
-          .getVersionArchive(page.versionistaUrl)
-          .then(content => {
-            const fileName = outputFileName(
-              {
-                siteId: site.id,
-                pageId: page.id,
-                versionId: 'all'
-              },
-              'archive',
-              'zip');
-            return writeFile(fileName, content, null);
-          })
-          .catch(error => {
-            // emit messages here and allow the process to continue
-            encounteredErrors = true;
-            console.error(error.message);
-          });
-        workTasks.push(savedArchive);
-
-        // page.versions.forEach(version => {
-        //   if (version.hasContent && args['--save-content']) {
-        //     const savedFile = scraper
-        //       .getVersionRawContent(version.url)
-        //       .then(html => writeFile(outputFileName(version), html))
-        //       .catch(error => {
-        //         encounteredErrors = true;
-
-        //         // Do some nice logging for a failure to get content. Also
-        //         // don't stop the works for this particular error.
-        //         if (error.code === 'VERSIONISTA:NO_VERSION_CONTENT') {
-        //           console.error(error.message);
-        //           console.error('  Requested urls:', error.urls);
-        //           console.error(`  Raw response: "${error.formattedContent}"`);
-        //         }
-        //         else {
-        //           throw error;
-        //         }
-        //       });
-        //     workTasks.push(savedFile);
-        //   }
-        // });
-      });
-    });
-    return Promise.all(workTasks).then(() => sites);
-  })
-  // format and save
+// save the metadata as-is before doing more work
+basicMetadata
   .then(data => formatter(data, {
     email: args['--email'],
     includeDiffs: args['--save-diffs'],
@@ -246,13 +221,130 @@ scraper.logIn()
     else {
       process.stdout.write(formatted);
     }
-  })
+  });
+
+if (args['--save-content']) {
+  basicMetadata = basicMetadata.then(sites => {
+    const workTasks = [];
+    sites.forEach(site => {
+      site.pages
+        .filter(pageHasDownloadableVersions)
+        .forEach(page => {
+          const savedArchive = scraper
+            .getVersionArchive(page.versionistaUrl)
+            .then(content => {
+              const fileName = outputFileName(
+                {
+                  siteId: site.id,
+                  pageId: page.id,
+                  versionId: 'all'
+                },
+                'archive',
+                'zip');
+              return writeFile(fileName, content, null);
+            })
+            .catch(error => {
+              // emit messages here and allow the process to continue
+              encounteredErrors++;
+              writeError(error.message);
+            });
+          workTasks.push(savedArchive);
+        });
+    });
+    return Promise.all(workTasks);
+  });
+}
+
+basicMetadata
   .catch(error => {
     console.error(error.stack);
-    encounteredErrors = true;
+    encounteredErrors++;
   })
   .then(() => {
     const seconds = Math.round((Date.now() - startTime) / 1000);
     console.error(`Completed in ${seconds} seconds`);
+    if (encounteredErrors) {
+      console.error(`  with ${encounteredErrors} errors`);
+    }
+    flushErrors();
     process.exit(encounteredErrors ? 1 : 0);
   });
+
+
+  // // save versions
+  // .then(sites => {
+  //   if (!args['--save-content']) return sites;
+
+  //   const workTasks = [];
+  //   sites.forEach(site => {
+  //     site.pages.forEach(page => {
+  //       const savedArchive = scraper
+  //         .getVersionArchive(page.versionistaUrl)
+  //         .then(content => {
+  //           const fileName = outputFileName(
+  //             {
+  //               siteId: site.id,
+  //               pageId: page.id,
+  //               versionId: 'all'
+  //             },
+  //             'archive',
+  //             'zip');
+  //           return writeFile(fileName, content, null);
+  //         })
+  //         .catch(error => {
+  //           // emit messages here and allow the process to continue
+  //           encounteredErrors = true;
+  //           console.error(error.message);
+  //         });
+  //       workTasks.push(savedArchive);
+
+  //       // page.versions.forEach(version => {
+  //       //   if (version.hasContent && args['--save-content']) {
+  //       //     const savedFile = scraper
+  //       //       .getVersionRawContent(version.url)
+  //       //       .then(html => writeFile(outputFileName(version), html))
+  //       //       .catch(error => {
+  //       //         encounteredErrors = true;
+
+  //       //         // Do some nice logging for a failure to get content. Also
+  //       //         // don't stop the works for this particular error.
+  //       //         if (error.code === 'VERSIONISTA:NO_VERSION_CONTENT') {
+  //       //           console.error(error.message);
+  //       //           console.error('  Requested urls:', error.urls);
+  //       //           console.error(`  Raw response: "${error.formattedContent}"`);
+  //       //         }
+  //       //         else {
+  //       //           throw error;
+  //       //         }
+  //       //       });
+  //       //     workTasks.push(savedFile);
+  //       //   }
+  //       // });
+  //     });
+  //   });
+  //   return Promise.all(workTasks).then(() => sites);
+  // })
+  // // format and save
+  // .then(data => formatter(data, {
+  //   email: args['--email'],
+  //   includeDiffs: args['--save-diffs'],
+  //   includeContent: args['--save-content'],
+  //   outputFileName: outputFileName
+  // }))
+  // .then(formatted => {
+  //   if (args['--output']) {
+  //     return writeFile(path.basename(args['--output']), formatted);
+  //   }
+  //   else {
+  //     process.stdout.write(formatted);
+  //   }
+  // })
+  // .catch(error => {
+  //   console.error(error.stack);
+  //   encounteredErrors = true;
+  // })
+  // .then(() => {
+  //   const seconds = Math.round((Date.now() - startTime) / 1000);
+  //   console.error(`Completed in ${seconds} seconds`);
+  //   process.exit(encounteredErrors ? 1 : 0);
+  // });

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -360,9 +360,13 @@ function archivePageVersions (page, versions) {
           }
         }))
         .resume()
-        // .on('data', () => null)
         .on('error', reject)
-        .on('end', resolve);
+        .on('end', () => {
+          if (unmatchedVersions.size > 0) {
+            return reject(new Error(`${unmatchedVersions.size} versions not found in downloaded archive: ${Array.from(unmatchedVersions)} (Page ${page.id})`));
+          }
+          resolve();
+        })
     }))
     .catch(error => {
       // emit messages here and allow the process to continue

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -315,7 +315,7 @@ if (args['--save-content']) {
                       // match the timestamps on the version records. So...
                       // find the closest matching timestamp, but also require
                       // it to be within a narrow threshold.
-                      const allowableTimeframe = 5 * 60 * 1000;
+                      const allowableTimeframe = 30 * 60 * 1000;
                       const fileVersion = minimum(page.versions, version => {
                         const value = Math.abs(version.date - fileDate);
                         return (value < allowableTimeframe) ? value : null;

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -2,10 +2,13 @@
 'use strict';
 
 const path = require('path');
+const stream = require('stream');
 const fs = require('fs-promise');
-const neodoc = require('neodoc');
 const mkdirp = require('mkdirp');
+const neodoc = require('neodoc');
+const unzip = require('unzip-stream');
 const Versionista = require('..');
+require('../lib/polyfill');
 
 const formatters = {
   csv: require('../lib/formatters/csv.js'),
@@ -34,6 +37,8 @@ Options:
   --save-content       Save raw HTML of each version. Files are written to the
                        working directory or, if --output is specified, the same
                        directory as the output file.
+  --save-all-content   Like --save-content, but saves ALL versions, regardless
+                       of --before/--after date criteria.
   --save-diffs         Save HTML of diffs between versions. Outputs in the same
                        fashion as --save-content.
 `);
@@ -42,6 +47,10 @@ args['--email'] = args['--email'] || process.env.VERSIONISTA_EMAIL;
 args['--password'] = args['--password'] || process.env.VERSIONISTA_PASSWORD;
 if (!args['--email'] || !args['--password']) {
   console.error('You must specify an e-mail and password for Versionista, either with the --email and --password arguments or with environment variables (VERSIONISTA_EMAIL, VERSIONISTA_PASSWORD).');
+}
+
+if (args['--save-all-content']) {
+  args['--save-content'] = 'all';
 }
 
 if (args['--before']) {
@@ -122,6 +131,19 @@ function flushErrors () {
 
 function pageHasDownloadableVersions (page) {
   return page.versions.some(version => version.hasContent);
+}
+
+function minimum (items, getValue = Number) {
+  let smallestValue = Infinity;
+  let smallestItem = null;
+  for (let item of items) {
+    let value = getValue(item);
+    if (value != null && value < smallestValue) {
+      smallestValue = value;
+      smallestItem = item;
+    }
+  }
+  return smallestItem;
 }
 
 const scraper = new Versionista({
@@ -226,34 +248,103 @@ basicMetadata
   });
 
 if (args['--save-content']) {
+  const unmatchedVersions = new Set();
   basicMetadata = basicMetadata.then(sites => {
     const workTasks = [];
     sites.forEach(site => {
       site.pages
         .filter(pageHasDownloadableVersions)
         .forEach(page => {
-          const savedArchive = scraper
-            .getVersionArchive(page.versionistaUrl)
+          page.versions.forEach(version => {
+            unmatchedVersions.add(version.versionId);
+          });
+
+          let baseDirectory = process.cwd();
+          if (args['--output']) {
+            baseDirectory = path.dirname(args['--output']);
+          }
+          const pageDirectory = `${site.id}-${page.id}`;
+          const pagePath = path.join(baseDirectory, pageDirectory);
+          const task = fs.ensureDir(pagePath)
+            .then(() => scraper.getVersionArchive(page.versionistaUrl))
             .then(content => {
-              const fileName = outputFileName(
-                {
-                  siteId: site.id,
-                  pageId: page.id,
-                  versionId: 'all'
-                },
-                'archive',
-                'zip');
-              return writeFile(fileName, content, null);
+              return new Promise((resolve, reject) => {
+                let writing = 1;
+                let errors = [];
+                const complete = (error) => {
+                  error && errors.push(error);
+                  writing = Math.max(0, writing - 1);
+                  if (writing === 0) {
+                    if (errors.length) {
+                      reject(errors.map(error => error.message).join('\n'));
+                    }
+                    else {
+                      resolve();
+                    }
+                  }
+                };
+                const contentStream = new stream.PassThrough();
+                contentStream.end(content);
+                contentStream.pipe(unzip.Parse())
+                  .on('entry', entry => {
+                    if (entry.type === 'File') {
+                      const [_, year, month, day, hour, minute, second, extension = ''] =
+                        entry.path.match(/^(\d{4})(\d\d)(\d\d)(\d\d)(\d\d)(\d\d)[^\.]*(\..*)?$/);
+                      const isoDate = `${year}-${month}-${day}T${hour}:${minute}:${second}Z`;
+                      const fileDate = new Date(isoDate);
+
+                      // Frustratingly, the timestamps on the files do not
+                      // match the timestamps on the version records. So...
+                      // find the closest matching timestamp, but also require
+                      // it to be within a narrow threshold.
+                      const allowableTimeframe = 5 * 60 * 1000;
+                      const fileVersion = minimum(page.versions, version => {
+                        const value = Math.abs(version.date - fileDate);
+                        return (value < allowableTimeframe) ? value : null;
+                      });
+
+                      let outputName = entry.path;
+                      if (fileVersion) {
+                        outputName = `version-${fileVersion.versionId}${extension}`;
+                        unmatchedVersions.delete(fileVersion.versionId);
+                      }
+                      else if (args['--save-content'] !== 'all') {
+                        resolve();
+                        entry.autodrain();
+                        return;
+                      }
+
+                      const versionFile = path.join(pagePath, outputName);
+                      entry
+                        .pipe(fs.createWriteStream(versionFile))
+                        .on('error', complete)
+                        .on('close', () => complete());
+
+                      writing++;
+                    }
+                    else {
+                      entry.autodrain();
+                    }
+                  })
+                  .on('end', () => complete());
+              });
             })
             .catch(error => {
               // emit messages here and allow the process to continue
               encounteredErrors++;
               writeError(error.message);
             });
-          workTasks.push(savedArchive);
+          workTasks.push(task);
         });
     });
-    return Promise.all(workTasks);
+    return Promise.all(workTasks)
+      .then(tasks => {
+        if (unmatchedVersions.size > 0) {
+          encounteredErrors++;
+          writeError(`${unmatchedVersions.size} versions not found in downloaded archives: ${Array.from(unmatchedVersions)}`);
+        }
+      })
+      .then(() => sites);
   });
 }
 
@@ -271,82 +362,3 @@ basicMetadata
     flushErrors();
     process.exit(encounteredErrors ? 1 : 0);
   });
-
-
-  // // save versions
-  // .then(sites => {
-  //   if (!args['--save-content']) return sites;
-
-  //   const workTasks = [];
-  //   sites.forEach(site => {
-  //     site.pages.forEach(page => {
-  //       const savedArchive = scraper
-  //         .getVersionArchive(page.versionistaUrl)
-  //         .then(content => {
-  //           const fileName = outputFileName(
-  //             {
-  //               siteId: site.id,
-  //               pageId: page.id,
-  //               versionId: 'all'
-  //             },
-  //             'archive',
-  //             'zip');
-  //           return writeFile(fileName, content, null);
-  //         })
-  //         .catch(error => {
-  //           // emit messages here and allow the process to continue
-  //           encounteredErrors = true;
-  //           console.error(error.message);
-  //         });
-  //       workTasks.push(savedArchive);
-
-  //       // page.versions.forEach(version => {
-  //       //   if (version.hasContent && args['--save-content']) {
-  //       //     const savedFile = scraper
-  //       //       .getVersionRawContent(version.url)
-  //       //       .then(html => writeFile(outputFileName(version), html))
-  //       //       .catch(error => {
-  //       //         encounteredErrors = true;
-
-  //       //         // Do some nice logging for a failure to get content. Also
-  //       //         // don't stop the works for this particular error.
-  //       //         if (error.code === 'VERSIONISTA:NO_VERSION_CONTENT') {
-  //       //           console.error(error.message);
-  //       //           console.error('  Requested urls:', error.urls);
-  //       //           console.error(`  Raw response: "${error.formattedContent}"`);
-  //       //         }
-  //       //         else {
-  //       //           throw error;
-  //       //         }
-  //       //       });
-  //       //     workTasks.push(savedFile);
-  //       //   }
-  //       // });
-  //     });
-  //   });
-  //   return Promise.all(workTasks).then(() => sites);
-  // })
-  // // format and save
-  // .then(data => formatter(data, {
-  //   email: args['--email'],
-  //   includeDiffs: args['--save-diffs'],
-  //   includeContent: args['--save-content'],
-  //   outputFileName: outputFileName
-  // }))
-  // .then(formatted => {
-  //   if (args['--output']) {
-  //     return writeFile(path.basename(args['--output']), formatted);
-  //   }
-  //   else {
-  //     process.stdout.write(formatted);
-  //   }
-  // })
-  // .catch(error => {
-  //   console.error(error.stack);
-  //   encounteredErrors = true;
-  // })
-  // .then(() => {
-  //   const seconds = Math.round((Date.now() - startTime) / 1000);
-  //   console.error(`Completed in ${seconds} seconds`);
-  //   process.exit(encounteredErrors ? 1 : 0);
-  // });

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -229,6 +229,7 @@ function archivePageVersions (page, versions) {
   return fs.ensureDir(pagePath)
     .then(() => new Promise((resolve, reject) => {
       scraper.getVersionArchiveEntries(page.versionistaUrl)
+        .on('error', reject)
         .pipe(stream.Transform({
           objectMode: true,
           transform: function (entry, encoding, callback) {

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -270,9 +270,12 @@ if (args['--save-content']) {
       site.pages
         .filter(pageHasDownloadableVersions)
         .forEach(page => {
-          page.versions.forEach(version => {
-            unmatchedVersions.add(version.versionId);
-          });
+          // track list of versions that we *should* see in archives
+          page.versions
+            .filter(version => version.hasContent)
+            .forEach(version => {
+              unmatchedVersions.add(version.versionId);
+            });
 
           let baseDirectory = process.cwd();
           if (args['--output']) {

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -308,20 +308,19 @@ let pages = sites
 let versions = pages
   .then(pages => {
     const versionsForPages = pages.map(page => {
-      const versions = scraper.getVersions(page.versionistaUrl);
-      const relevantVersions = versions
+      const versions = scraper.getVersions(page.versionistaUrl)
         .then(versions => versions.filter(isInRequestedDateRange))
         .then(versions => {
           page.versions = versions;
           return versions;
         });
 
-      const archived = relevantVersions
+      const archived = versions
         .then(archivePageVersions.bind(null, page));
-      const diffed = relevantVersions
+      const diffed = versions
         .then(versions => Promise.all(versions.map(archiveVersionDiff)))
 
-      return Promise.all([diffed, archived]).then(() => relevantVersions);
+      return Promise.all([diffed, archived]).then(() => versions);
     });
     return Promise.all(versionsForPages).then(flatten);
   })

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -187,6 +187,14 @@ let basicMetadata = scraper.logIn()
                 const newVersions = versions.filter(version => isInRequestedDateRange(version.date));
                 console.error(`In ${page.url}:\n  ${versions.length} versions\n  ${newVersions.length} new versions`);
 
+                // FIXME: this is duplicated in the content-saving logic below
+                let baseDirectory = process.cwd();
+                if (args['--output']) {
+                  baseDirectory = path.dirname(args['--output']);
+                }
+                const pageDirectory = `${site.id}-${page.id}`;
+                const pagePath = path.join(baseDirectory, pageDirectory);
+
                 return Promise.all(newVersions.map(version => {
                   if (!version.diffWithPreviousUrl) return version;
                   return scraper.getVersionDiff(version.diffWithPreviousUrl)
@@ -198,11 +206,13 @@ let basicMetadata = scraper.logIn()
                         };
 
                         if (args['--save-diffs']) {
-                          return writeFile(
-                            outputFileName(version, 'diff'),
-                            diff.content
-                          )
-                          .then(() => version);
+                          const fileName = `diff-${version.versionId}.html`;
+                          return fs.ensureDir(pagePath)
+                            .then(() => fs.writeFile(
+                              path.join(pagePath, fileName),
+                              diff.content
+                            ))
+                            .then(() => version);
                         }
                       }
 

--- a/lib/flatten.js
+++ b/lib/flatten.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function (array) {
+  return array.reduce((flattened, item) => flattened.concat(item), []);
+};

--- a/lib/formatters/csv.js
+++ b/lib/formatters/csv.js
@@ -30,6 +30,7 @@ module.exports = function formatCsv (sites, options = {}) {
   }
   if (options.includeContent) {
     rows[0].push('Version File');
+    rows[0].push('Version Hash');
   }
 
   // TODO: this would be better as a flatmap
@@ -79,6 +80,7 @@ function rowForVersion (site, page, version, options) {
     else {
       row.push('');
     }
+    row.push(version.hash || '');
   }
 
   return row;

--- a/lib/formatters/csv.js
+++ b/lib/formatters/csv.js
@@ -65,7 +65,7 @@ function rowForVersion (site, page, version, options) {
 
   if (options.includeDiffs) {
     if (version.diff) {
-      row.push(options.outputFileName(version, 'diff'));
+      row.push(version.diff.path);
     }
     else {
       row.push('');
@@ -74,7 +74,7 @@ function rowForVersion (site, page, version, options) {
 
   if (options.includeContent) {
     if (version.hasContent) {
-      row.push(options.outputFileName(version, 'content'));
+      row.push(version.filePath);
     }
     else {
       row.push('');

--- a/lib/formatters/json-stream.js
+++ b/lib/formatters/json-stream.js
@@ -21,20 +21,6 @@ module.exports = function formatJsonStream (sites, options = {}) {
           versionistaSiteUrl: site.url
         }, version);
 
-        if (formatted.diff) {
-          formatted.diff = {
-            length: formatted.diff.length,
-            hash: formatted.diff.hash
-          };
-          if (options.includeDiff) {
-            formatted.diff.diff = options.outputFileName(version, 'diff');
-          }
-        }
-
-        if (version.hasContent && options.includeContent) {
-          formatted.content = options.outputFileName(version, 'content');
-        }
-
         rows.push(formatted);
       });
     });

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Accepted for ES-2017, so safe to use
+if (!String.prototype.padStart) {
+  Object.defineProperty(String.prototype, 'padStart', {
+    enumerable: false,
+    value: function (length, padString = ' ') {
+      const addLength = length - this.length;
+      if (addLength > 0) {
+        return padString.repeat(addLength).slice(0, addLength) + this;
+      }
+      return this;
+    }
+  });
+  Object.defineProperty(String.prototype, 'padEnd', {
+    enumerable: false,
+    value: function (length, padString = ' ') {
+      const addLength = length - this.length;
+      if (addLength > 0) {
+        return this + padString.repeat(addLength).slice(0, addLength);
+      }
+      return this;
+    }
+  });
+}

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -534,9 +534,15 @@ function createClient ({userAgent = USER_AGENT, maxSockets = MAX_SOCKETS, sleepE
         availableSockets++;
         sleepIfNecessary();
 
-        if (error) {
-          // if the server hung up, take a break and try again
-          if (error.code === 'ECONNRESET' && task.retries < MAX_RETRIES) {
+        // we want to auto-retry on gateway errors
+        // TODO: should this logic be customizable as an option?
+        const badResponse = response
+          && (response.statusCode >= 502 && response.status <= 504);
+
+        if (error || badResponse) {
+          // if the server hung up or was unhappy, take a break & try again
+          const retryable = badResponse || error.code === 'ECONNRESET';
+          if (retryable && task.retries < MAX_RETRIES) {
             task.retries += 1;
             queue.unshift(task);
             sleep(sleepFor * task.retries * 2);

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -375,10 +375,12 @@ class Versionista {
     // FIXME: should really stream from client
     this.getVersionArchive(pageUrl)
       .then(content => {
+        // TODO: clean up all the error juggling here with pumpify
         const contentStream = new stream.PassThrough();
         contentStream.end(content);
         contentStream
           .pipe(unzip.Parse())
+          .on('error', error => entryStream.emit('error', error))
           .pipe(stream.Transform({
             objectMode: true,
             transform: function (entry, encoding, callback) {
@@ -398,10 +400,11 @@ class Versionista {
               }
             }
           }))
+          .on('error', error => entryStream.emit('error', error))
           .pipe(entryStream);
       })
       .catch(error => {
-        entryStream.emit('error', error);
+        process.nextTick(() => entryStream.emit('error', error));
       });
 
     return entryStream;

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -196,10 +196,14 @@ class Versionista {
         url = joinUrlPaths(pageUrl, versionId);
       }
 
+      const is404Page = xpathArray(versionRow, "./td[2]/*[@title]")
+        .some(node => /header response code\W+404/i.test(node.title));
+
       return Object.assign(parseVersionistaUrl(url), {
         url,
         date,
-        hasContent
+        hasContent,
+        is404Page
       });
     }
 

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -399,6 +399,9 @@ class Versionista {
             }
           }))
           .pipe(entryStream);
+      })
+      .catch(error => {
+        entryStream.emit('error', error);
       });
 
     return entryStream;

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -3,6 +3,7 @@
 const crypto = require('crypto');
 const request = require('request');
 const jsdom = require('jsdom');
+const Entities = require('html-entities').AllHtmlEntities;
 
 const MAX_SOCKETS = 6;
 const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36';
@@ -256,7 +257,8 @@ class Versionista {
           // The URL from the API is time limited, so prioritize the request
           immediate: true,
           // A version may be binary data (for PDFs, videos, etc.)
-          encoding: null
+          encoding: null,
+          parseBody: false
         });
       })
       // The raw source is the text of the `<pre>` element. A different type of
@@ -264,33 +266,40 @@ class Versionista {
       // but it appears that the source there has been parsed, cleaned up
       // (made valid HTML), and had Versionista analytics inserted.
       .then(response => {
-        const actualResponse = response.httpResponse || response;
         // Sometimes a version may have no content (e.g. a page was removed).
         // This is OK.
-        if (actualResponse.body.toString() === '') {
+        if (response.body.toString() === '') {
           return '';
         }
-        // Are we dealing with a DOM?
-        else if (response.document) {
-          const document = response.document;
-          const pre = document.querySelector('pre');
-          if (pre) {
-            return pre.textContent;
+        // Are we dealing with HTML?
+        else if (typeof response.body === 'string') {
+          // we don't actually parse this content with JSDOM because it could be
+          // big enough to consume all our available memory. Instead, do some
+          // dumb, simplistic decoding.
+          const openPreIndex = response.body.indexOf('<pre>');
+          const closePreIndex = response.body.indexOf('</pre>', openPreIndex);
+          if (openPreIndex > -1 && closePreIndex > -1) {
+            const formattedContent = response.body.slice(
+              openPreIndex + 5,
+              closePreIndex);
+            const encodedContent = formattedContent.replace(/<[^>]+>/g, '');
+            const entities = new Entities();
+            return entities.decode(encodedContent);
           }
           // Handle cache timeout (see note on temporary URLs above)
           else if (document.body.textContent.match(/cache expired/i) && retries) {
             return this.getVersionRawContent(versionUrl, retries - 1);
           }
         }
-        else if (Buffer.isBuffer(actualResponse.body)) {
-          return actualResponse.body;
+        else if (Buffer.isBuffer(response.body)) {
+          return response.body;
         }
 
         // FAILURE!
         const error = new Error(`Can't find raw content for ${versionUrl}`);
         error.code = 'VERSIONISTA:NO_VERSION_CONTENT';
-        error.urls = [versionUrl, apiUrl, actualResponse.request.uri.href];
-        error.receivedContent = actualResponse.body;
+        error.urls = [versionUrl, apiUrl, response.request.uri.href];
+        error.receivedContent = response.body;
         throw error;
       });
   }

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const request = require('request');
 const jsdom = require('jsdom');
 const Entities = require('html-entities').AllHtmlEntities;
+const {xpath, xpathArray, xpathNode} = require('./xpath');
 
 const MAX_SOCKETS = 6;
 const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36';
@@ -515,42 +516,11 @@ function hash (text) {
   return crypto.createHash('sha256').update(text).digest('hex');
 }
 
-function xpath (node, expression) {
-  const document = node.nodeType === node.DOCUMENT_NODE ? node : node.ownerDocument;
-  const type = document.defaultView.XPathResult.ORDERED_NODE_ITERATOR_TYPE;
-  const iterator = document.evaluate(expression, node, null, type, null);
-  iterator.map = function (transform) {
-    let item;
-    let result = [];
-    while (item = iterator.iterateNext()) {
-      result.push(transform(item));
-    }
-    return result;
-  }
-  return iterator;
-}
-
-function xpathArray (node, expression) {
-  return xpath(node, expression).map(item => item);
-}
-
-function xpathNode (node, expression) {
-  const iterator = xpath(node, expression);
-  return iterator.iterateNext();
-}
-
 function joinUrlPaths (basePath, ...paths) {
   return paths.reduce((finalPath, urlPath) => {
     const delimiter = finalPath.endsWith('/') ? '' : '/';
     return finalPath + delimiter + urlPath;
   }, basePath);
-}
-
-function promisedInput (func) {
-  return function () {
-    return Promise.all(Array.from(arguments).map(Promise.resolve))
-      .then(resolvedArgs => func.apply(this, resolvedArgs))
-  }
 }
 
 function getPagingUrls (window) {

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -9,7 +9,7 @@ const {xpath, xpathArray, xpathNode} = require('./xpath');
 const MAX_SOCKETS = 6;
 const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36';
 const SLEEP_EVERY = 40;
-const SLEEP_FOR = 5000;
+const SLEEP_FOR = 1000;
 const MAX_RETRIES = 3;
 
 /**

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -315,7 +315,11 @@ class Versionista {
 
   getVersionArchive (pageUrl) {
     const createArchiveUrl = joinUrlPaths(pageUrl, 'archive');
-    return this.request({url: createArchiveUrl, parseBody: false})
+    return this.request({
+      url: createArchiveUrl,
+      parseBody: false,
+      retryIf: response => response.statusCode !== 200
+    })
       .then(response => {
         if (response.statusCode !== 200) {
           throw new Error(`Error creating archive for ${pageUrl}: ${response.body}`);
@@ -551,10 +555,7 @@ function createClient ({userAgent = USER_AGENT, maxSockets = MAX_SOCKETS, sleepE
         availableSockets++;
         sleepIfNecessary();
 
-        // we want to auto-retry on gateway errors
-        // TODO: should this logic be customizable as an option?
-        const badResponse = response
-          && (response.statusCode >= 502 && response.status <= 504);
+        const badResponse = response && task.retryIf(response);
 
         if (error || badResponse) {
           // if the server hung up or was unhappy, take a break & try again
@@ -579,11 +580,15 @@ function createClient ({userAgent = USER_AGENT, maxSockets = MAX_SOCKETS, sleepE
     }
   }
 
+  // By default, auto-retry on gateway errors
+  const defaultRetryIf = r => (r.statusCode >= 502 && r.statusCode <= 504);
+
   return function (options) {
     return new Promise((resolve, reject) => {
       const task = {
         options: options,
         retries: (options.retry === false) ? MAX_RETRIES : 0,
+        retryIf: options.retryIf || defaultRetryIf,
         resolve,
         reject
       };

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -150,6 +150,7 @@ class Versionista {
             row.querySelector('.kwlastChange').textContent);
 
           return {
+            id: parseVersionistaUrl(link.href).siteId,
             name: link.textContent.trim(),
             url: link.href,
             lastChange: new Date(window.requestDate - lastUpdateSecondsAgo * 1000)
@@ -301,6 +302,44 @@ class Versionista {
         error.urls = [versionUrl, apiUrl, response.request.uri.href];
         error.receivedContent = response.body;
         throw error;
+      });
+  }
+
+  getVersionArchive (pageUrl) {
+    const createArchiveUrl = joinUrlPaths(pageUrl, 'archive');
+    return this.request({url: createArchiveUrl, parseBody: false})
+      .then(response => {
+        if (response.statusCode !== 200) {
+          throw new Error(`Error creating archive for ${pageUrl}: ${response.body}`);
+        }
+
+        const startTime = Date.now();
+        const pollForReadiness = (url, interval = 1 * 1000, maxTime = 5 * 60 * 1000) => {
+          const cacheBreaker = `?${Math.random()}`;
+          url = url + cacheBreaker;
+          return this.request({url, method: 'HEAD', parseBody: false})
+            .then(response => {
+              if (response.statusCode === 200) {
+                return true;
+              }
+              else if (Date.now() > startTime + maxTime) {
+                throw new Error(`Timed out requesting archive for ${pageUrl}`);
+              }
+              else {
+                return pollForReadiness(url, interval, maxTime);
+              }
+            });
+        };
+
+        const archiveUrl = `https://s3.amazonaws.com/versionista-packs/${response.body}`;
+        return pollForReadiness(archiveUrl)
+          .then(() => this.request({
+            url: archiveUrl,
+            immediate: true,
+            encoding: null,
+            parseBody: false
+          }))
+          .then(response => response.body);
       });
   }
 
@@ -529,10 +568,12 @@ function getPageDetailData (window) {
     const remoteLink = xpathNode(row, "./td[a][1]/a").href;
     // NOTE: the URL is not encoded here (!)
     const remoteUrl = remoteLink.slice(remoteLink.indexOf('?') + 1);
+    const versionistaUrl = xpathNode(row, "./td[a][2]/a").href;
 
     return {
+      id: parseVersionistaUrl(versionistaUrl).pageId,
       url: remoteUrl,
-      versionistaUrl: xpathNode(row, "./td[a][2]/a").href,
+      versionistaUrl: versionistaUrl,
       title: xpathNode(row, "./td[a][3]").textContent.trim(),
       lastChange: updateTime
     };

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -487,6 +487,20 @@ class Versionista {
   }
 }
 
+[
+  'getSites',
+  'getPages',
+  'getVersions',
+  'getVersionRawContent',
+  'getVersionArchive',
+  'getVersionDiff'
+].forEach(method => {
+  const implementation = Versionista.prototype[method];
+  Versionista.prototype[method] = function () {
+    return this.logIn().then(() => implementation.apply(this, arguments));
+  }
+});
+
 function createClient ({userAgent = USER_AGENT, maxSockets = MAX_SOCKETS, sleepEvery = SLEEP_EVERY, sleepFor = SLEEP_FOR} = {}) {
   const cookieJar = request.jar();
   const versionistaRequest = request.defaults({

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -395,7 +395,7 @@ class Versionista {
       .then(response => {
         if (response.statusCode >= 400) {
           const error = new Error(
-            `API Error from '${response.request.href}': ${response.body}`);
+            `API Error from '${response.request.href}' (Diff URL: ${diffUrl}): ${response.body}`);
           error.code = 'VERSIONISTA:API_ERROR';
           throw error;
         }

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -1,9 +1,12 @@
 'use strict';
 
 const crypto = require('crypto');
+const stream = require('stream');
 const request = require('request');
 const jsdom = require('jsdom');
 const Entities = require('html-entities').AllHtmlEntities;
+const unzip = require('unzip-stream');
+const flatten = require('./flatten');
 const {xpath, xpathArray, xpathNode} = require('./xpath');
 
 const MAX_SOCKETS = 6;
@@ -349,6 +352,67 @@ class Versionista {
   }
 
   /**
+   * Returns a stream of *file* entry objects. These are basically `Entry`
+   * objects from the `unzip-stream` library, with a few additions:
+   * - {Date} date  A date object representing the parsed version capture date
+   * - {String} extension  The file extension
+   * - Emits a `hash` event with the file's SHA-256 hash as a buffer
+   *
+   * This conveniently also skips directory entries, as we don't ever expect
+   * them to be present in Versionista archives.
+   *
+   * Note that you MUST either read the entirety of each entry object stream OR
+   * call `.autodrain()` on it. Failure to do so could leave memory in a bad
+   * state :(
+   *
+   * @param {String} pageUrl
+   * @returns {Entry}
+   */
+  getVersionArchiveEntries (pageUrl) {
+    const entryStream = new stream.PassThrough({objectMode: true});
+    const parseArchiveEntryName = this.parseArchiveEntryName;
+
+    // FIXME: should really stream from client
+    this.getVersionArchive(pageUrl)
+      .then(content => {
+        const contentStream = new stream.PassThrough();
+        contentStream.end(content);
+        contentStream
+          .pipe(unzip.Parse())
+          .pipe(stream.Transform({
+            objectMode: true,
+            transform: function (entry, encoding, callback) {
+              if (entry.type === 'File') {
+                Object.assign(entry, parseArchiveEntryName(entry.path))
+
+                entry
+                  .pipe(crypto.createHash('sha256'))
+                  .on('data', hash => entry.emit('hash', hash));
+
+                entry.pause();
+                callback(null, entry);
+              }
+              else {
+                entry.autodrain();
+                callback();
+              }
+            }
+          }))
+          .pipe(entryStream);
+      });
+
+    return entryStream;
+  }
+
+  parseArchiveEntryName (fileName) {
+    const [_, year, month, day, hour, minute, second, extension = ''] =
+      fileName.match(/^(\d{4})(\d\d)(\d\d)(\d\d)(\d\d)(\d\d)[^\.]*(\..*)?$/);
+    const isoDate = `${year}-${month}-${day}T${hour}:${minute}:${second}Z`;
+    const date = new Date(isoDate);
+    return {date, extension};
+  }
+
+  /**
    * Get information about a diff between two versions (including the diff
    * itself). Note this May return `null` if there is no diff (e.g. if
    * Versionista got no content/no response when it captured the version).
@@ -510,10 +574,6 @@ function parseVersionistaUrl (url) {
     pageId: ids[1],
     versionId: ids[2] && ids[2].split(':')[0]
   };
-}
-
-function flatten (array) {
-  return array.reduce((flattened, item) => flattened.concat(item), []);
 }
 
 function hash (text) {

--- a/lib/xpath.js
+++ b/lib/xpath.js
@@ -1,0 +1,31 @@
+'use strict';
+
+function xpath (node, expression) {
+  const document = node.nodeType === node.DOCUMENT_NODE ? node : node.ownerDocument;
+  const type = document.defaultView.XPathResult.ORDERED_NODE_ITERATOR_TYPE;
+  const iterator = document.evaluate(expression, node, null, type, null);
+  iterator.map = function (transform) {
+    let item;
+    let result = [];
+    while (item = iterator.iterateNext()) {
+      result.push(transform(item));
+    }
+    return result;
+  }
+  return iterator;
+}
+
+function xpathArray (node, expression) {
+  return xpath(node, expression).map(item => item);
+}
+
+function xpathNode (node, expression) {
+  const iterator = xpath(node, expression);
+  return iterator.iterateNext();
+}
+
+module.exports = {
+  xpath,
+  xpathArray,
+  xpathNode
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "jsdom": "^9.12.0",
     "mkdirp": "^0.5.1",
     "neodoc": "^1.4.0",
-    "request": "^2.81.0"
+    "request": "^2.81.0",
+    "unzip-stream": "^0.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "fs-promise": "^2.0.0",
+    "html-entities": "^1.2.0",
     "jsdom": "^9.12.0",
     "mkdirp": "^0.5.1",
     "neodoc": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -250,6 +250,10 @@ html-encoding-sniffer@^1.0.1:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+html-entities@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.0.tgz#41948caf85ce82fed36e4e6a0ed371a6664379e2"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,11 +79,22 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+balanced-match@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
   dependencies:
     tweetnacl "^0.14.3"
+
+binary@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
+  dependencies:
+    buffers "~0.1.1"
+    chainsaw "~0.1.0"
 
 boom@2.x.x:
   version "2.10.1"
@@ -91,9 +102,26 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
+brace-expansion@^1.0.0:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
+  dependencies:
+    balanced-match "^0.4.1"
+    concat-map "0.0.1"
+
+buffers@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+
+chainsaw@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
+  dependencies:
+    traverse ">=0.3.0 <0.4"
 
 co@^4.6.0:
   version "4.6.0"
@@ -104,6 +132,10 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
   dependencies:
     delayed-stream "~1.0.0"
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
 content-type-parser@^1.0.1:
   version "1.0.1"
@@ -210,11 +242,35 @@ fs-promise@^2.0.0:
     mz "^2.6.0"
     thenify-all "^1.6.0"
 
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+fstream@^1.0.10:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
+
 getpass@^0.1.1:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.6.tgz#283ffd9fc1256840875311c1b60e8c40187110e6"
   dependencies:
     assert-plus "^1.0.0"
+
+glob@^7.0.5:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
@@ -265,6 +321,17 @@ http-signature@~1.1.0:
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2, inherits@~2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -358,11 +425,17 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.26.0"
 
+minimatch@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
+  dependencies:
+    brace-expansion "^1.0.0"
+
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-mkdirp@^0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -394,6 +467,12 @@ object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  dependencies:
+    wrappy "1"
+
 optionator@^0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
@@ -408,6 +487,10 @@ optionator@^0.8.1:
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -451,6 +534,12 @@ request@^2.79.0, request@^2.81.0:
     tough-cookie "~2.3.0"
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
+
+rimraf@2:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+  dependencies:
+    glob "^7.0.5"
 
 safe-buffer@^5.0.1:
   version "5.0.1"
@@ -517,6 +606,10 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
+"traverse@>=0.3.0 <0.4":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -532,6 +625,13 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+unzip-stream@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/unzip-stream/-/unzip-stream-0.1.2.tgz#63a7695beedd9ae21ed228970b77896346234fa5"
+  dependencies:
+    binary "^0.3.0"
+    fstream "^1.0.10"
 
 uuid@^3.0.0:
   version "3.0.1"
@@ -567,6 +667,10 @@ whatwg-url@^4.3.0:
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
 xml-name-validator@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
This is big and amounts to a sizable restructuring. The main thing here is adding downloads of complete diff and version data (and also fixes #4 in the process—see details there about archive vs. other ways of getting raw version content).

This also makes the whole thing much more robust and able to grab the entire Versionista database in a single run without errors. (yay!)

Output is now in the format:

```
/output-directory                  # the directory of the file specified by the
  │                                # --output argument
  ├── output-file                  # this is the --output argument
  │
  └─┬ /{site id}-{version id}      # holds all output of content for a page
    │
    ├── diff-{version id}.html     # Versionista's diff for a version vs. the 
    │                              # previous one (note this is always HTML)
    └── version-{version id}.{ext} # Raw content of the page for a version.
                                   # {ext} is the file extension Versionista
                                   # assigned, which appears to be based on
                                   # the Content-Type header
```